### PR TITLE
feat: add scroll trigger to counter animation

### DIFF
--- a/src/app/(landing)/components/counter/index.tsx
+++ b/src/app/(landing)/components/counter/index.tsx
@@ -50,7 +50,12 @@ const CounterSection = () => {
                 <h2 className='text-4xl leading-4xl md:text-5xl md:leading-5xl text-primary'>
                   <div>
                     <span>
-                      <CountUp duration={3} start={0} end={item.value} />
+                      <CountUp
+                        duration={3}
+                        start={0}
+                        end={item.value}
+                        enableScrollSpy={true}
+                      />
                     </span>
                     {item.unit}
                   </div>


### PR DESCRIPTION
### PR Type

---

- [ ] Add Feature
- [x] Update Feature
- [ ] Remove Feature
- [ ] Fix Bug
- [ ] Chore (Dependencies / Env / Build)

<br>

### Target Branch

---

12-animated-counter -> main

<br>

### Changes

---

- Enabled scroll-triggered animation in the counter component using `enableScrollSpy`
<br>

### Description & Screenshots

---

When the counter component scrolls into view, the animation now starts using `react-countup`’s `enableScrollSpy` feature.
No visual design changes. Functionality improvement only.

<br>

### Checklist

---

- [x] Code runs without errors
- [x] Tested in local environment
- [x] No unnecessary console logs or comments
